### PR TITLE
Solves the subunits per unit using real data from Unicode CLDR

### DIFF
--- a/data/subunits-per-unit.js
+++ b/data/subunits-per-unit.js
@@ -1,0 +1,39 @@
+'use strict';
+
+var subUnitsPerUnit = {};
+
+subUnitsPerUnit['BIF'] =
+subUnitsPerUnit['CLP'] =
+subUnitsPerUnit['CVE'] =
+subUnitsPerUnit['DJF'] =
+subUnitsPerUnit['GNF'] =
+subUnitsPerUnit['ISK'] =
+subUnitsPerUnit['JPY'] =
+subUnitsPerUnit['KMF'] =
+subUnitsPerUnit['KRW'] =
+subUnitsPerUnit['PYG'] =
+subUnitsPerUnit['RWF'] =
+subUnitsPerUnit['UGX'] =
+subUnitsPerUnit['UYI'] =
+subUnitsPerUnit['VND'] =
+subUnitsPerUnit['VUV'] =
+subUnitsPerUnit['XAF'] =
+subUnitsPerUnit['XOF'] =
+subUnitsPerUnit['XPF'] = 1;
+
+subUnitsPerUnit['MGA'] =
+subUnitsPerUnit['MRU'] = 5;
+
+subUnitsPerUnit['BHD'] =
+subUnitsPerUnit['IQD'] =
+subUnitsPerUnit['JOD'] =
+subUnitsPerUnit['KWD'] =
+subUnitsPerUnit['LYD'] =
+subUnitsPerUnit['OMR'] =
+subUnitsPerUnit['TND'] =
+subUnitsPerUnit['CLF'] = 1000;
+
+module.exports = function (currency) {
+    return subUnitsPerUnit[currency] || 100;
+};
+

--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ var countryCurrencyMap = require('./data/country-currency');
 var currencySymbolMap = require('./data/symbol-map');
 var localeSeparatorsMap = require('./data/separators');
 var localePositionersMap = require('./data/positions');
+var subunitsPerUnit = require('./data/subunits-per-unit');
 
 var THOUSAND_MATCHER = /\B(?=(\d{3})+(?!\d))/g;
 var LOCALE_MATCHER = /^\s*([a-zA-Z]{2,4})(?:[-_][a-zA-Z]{4})?(?:[-_]([a-zA-Z]{2}|\d{3}))?\s*(?:$|[-_])/;
@@ -101,7 +102,7 @@ exports.formattingForLocale = function (locale, currencyCode) {
 
     return {
         showDecimalIfWhole: true,
-        subunitsPerUnit: 100, // TODO change 100 with real information
+        subunitsPerUnit: subunitsPerUnit(currencyCode),
         currencyCode: currencyCode,
         currencySymbol: currencySymbolMap[currencyCode] || currencyCode,
         currencyFormatter: findWithFallback(localePositionersMap, locale, localeParts),

--- a/test/index.js
+++ b/test/index.js
@@ -116,6 +116,21 @@ describe('banknote', function () {
             assert.equal(banknote.formatSubunitAmount(123456, options), '1.234,56 €');
         });
 
+        it('should work for "ja-JP" locale', function () {
+            const options = banknote.formattingForLocale('ja-JP');
+            assert.equal(banknote.formatSubunitAmount(123456, options), '¥123,456.0');
+        });
+
+        it('should work for "de" locale with "JPY" currency', function () {
+            const options = banknote.formattingForLocale('de-DE', 'JPY');
+            assert.equal(banknote.formatSubunitAmount(123406, options), '123.406,0 ¥');
+        });
+
+        it('should work for "no-NO" locale', function () {
+            const options = banknote.formattingForLocale('no-NO', 'MGA');
+            assert.equal(banknote.formatSubunitAmount(123456, options), '24 691,1 Ar');
+        });
+
         it('should work for "no" locale with "NOK" currency', function () {
             const options = banknote.formattingForLocale('no-NO', 'NOK');
             assert.equal(banknote.formatSubunitAmount(123456, options), '1 234,56 kr');


### PR DESCRIPTION
Replaces the default 100 value of the `subunitsPerUnit ` by real values extracted from https://unicode.org/cldr/charts/latest/supplemental/detailed_territory_currency_information.html#format_info