### PR TITLE
Added script to create Typescript declaration file using tsc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "banknote",
-  "version": "0.2.3",
+  "version": "0.2.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1617,6 +1617,12 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true
+    },
+    "typescript": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.6.tgz",
+      "integrity": "sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==",
       "dev": true
     },
     "uri-js": {

--- a/package.json
+++ b/package.json
@@ -1,15 +1,16 @@
 {
   "name": "banknote",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Module for handling currency formatting.",
   "main": "index.js",
   "scripts": {
-    "prepublish": "npm run lint && npm test",
+    "prepublish": "npm run lint && npm test && npm declaration",
     "update-cldr-data": "node update",
     "lint": "eslint .",
     "test": "mocha test",
     "benchmark": "node benchmark",
-    "tdd": "mocha --watch test"
+    "tdd": "mocha --watch test",
+    "declaration": "tsc && rm data/*.d.ts"
   },
   "repository": {
     "type": "git",
@@ -23,6 +24,7 @@
   "devDependencies": {
     "benchmark": "^2.1.4",
     "eslint": "^6.8.0",
-    "mocha": "^7.1.1"
+    "mocha": "^7.1.1",
+    "typescript": "^3.9.6"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "declaration": true,
+    "emitDeclarationOnly": true
+  },
+  "files": [
+    "./index.js"
+  ]
+}


### PR DESCRIPTION
Here is an alternative for creating the Typescript declaration file, as requested by @ruiaraujo in #13. As this is a generated file, the best would be to add it to `.gitignore` so that it is not accidentally checked in.

As Typescript's inclusion/exclusion logic does not allow to exclude the `data/*` files from being considered in the declaration creation, I just remove them afterwards.