### PR TITLE
Change zappr type to code

### DIFF
--- a/.zappr.yaml
+++ b/.zappr.yaml
@@ -1,1 +1,1 @@
-X-Zalando-Type: tools
+X-Zalando-Type: code


### PR DESCRIPTION
Change the repository type to code, since it is actually used to format money, and is business critical.